### PR TITLE
Fix compatibility with ruby 1.8.7.

### DIFF
--- a/lib/redmine_per_project_formatting/project_listener.rb
+++ b/lib/redmine_per_project_formatting/project_listener.rb
@@ -6,7 +6,7 @@ module RedminePerProjectFormatting
       options = p.module_options
       default_formatting = Setting.text_formatting_without_per_project
       content_tag(:p, f.select(:text_formatting,
-        Redmine::WikiFormatting.format_names.map {|f| [f, f.to_s]},
+        Redmine::WikiFormatting.format_names.map {|n| [n, n.to_s]},
         :include_blank => "Redmine setting (#{default_formatting})", :label => :setting_text_formatting
       )) +
       content_tag(:p,


### PR DESCRIPTION
Use another variable name in closure than the one in parent scope. It
seems that in ruby 1.8.7 (at least) closure overrides parent variable
value (i.e.  f is no longer a form once closure is evaluated).

Tested with ruby-1.8.7 / rails-3.2.21 / redmine 2.6.4.

P.S. Please note that I'm no ruby expert. I discovered this by trail & error. Original error in production.log when opening project settings was:

```
ActionView::Template::Error (wrong number of arguments (4 for 0)):
    25: <% @project.custom_field_values.each do |value| %>
    26:   <p><%= custom_field_tag_with_label :project, value %></p>
    27: <% end %>
    28: <%= call_hook(:view_projects_form, :project => @project, :form => f) %>
    29: </div>
    30: 
    31: <% if @project.new_record? %>
  lib/redmine/hook.rb:61:in `send'
  lib/redmine/hook.rb:61:in `call_hook'
  lib/redmine/hook.rb:61:in `each'
  lib/redmine/hook.rb:61:in `call_hook'
  lib/redmine/hook.rb:58:in `tap'
  lib/redmine/hook.rb:58:in `call_hook'
  lib/redmine/hook.rb:158:in `call_hook'
  app/views/projects/_form.html.erb:28:in `_app_views_projects__form_html_erb___1399533857_70058349748740'
  app/views/projects/_edit.html.erb:2:in `_app_views_projects__edit_html_erb__1980443437_70058348317780'
  app/helpers/application_helper.rb:1056:in `labelled_form_for'
  app/views/projects/_edit.html.erb:1:in `_app_views_projects__edit_html_erb__1980443437_70058348317780'
  app/views/common/_tabs.html.erb:22:in `_app_views_common__tabs_html_erb___189390908_70058348495820'
  app/views/common/_tabs.html.erb:21:in `each'
  app/views/common/_tabs.html.erb:21:in `_app_views_common__tabs_html_erb___189390908_70058348495820'
  app/helpers/application_helper.rb:328:in `render_tabs'
  app/views/projects/settings.html.erb:3:in `_app_views_projects_settings_html_erb__1881576150_70058348813160'
```

The latest version which works in our environment is 0.0.1.